### PR TITLE
Fix three critical code bugs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           ls -l outpkg/homebrew outpkg/scoop || true
 
       - name: Auto-push Homebrew formula (optional)
-        # if: secrets.GH_PAT != '' && secrets.HOMEBREW_TAP_REPO != ''
+        if: secrets.GH_PAT != '' && secrets.HOMEBREW_TAP_REPO != ''
         shell: bash
         run: |
           set -e
@@ -202,13 +202,13 @@ jobs:
           git push
 
       - name: Auto-push Scoop manifest (optional)
-        # if: secrets.GH_PAT != '' && secrets.SCOOP_BUCKET_REPO != ''
+        if: secrets.GH_PAT != '' && secrets.SCOOP_BUCKET_REPO != ''
         shell: bash
         run: |
           set -e
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          # git clone "https://${{ secrets.GH_PAT }}@github.com/${{ secrets.SCOOP_BUCKET_REPO }}.git" scooprepo
+          git clone "https://${{ secrets.GH_PAT }}@github.com/${{ secrets.SCOOP_BUCKET_REPO }}.git" scooprepo
           mkdir -p scooprepo/bucket
           cp outpkg/scoop/lucide-svg-rs.json scooprepo/bucket/lucide-svg-rs.json
           cd scooprepo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,14 @@ impl LucideClient {
             let src = entry.path();
             if src.extension().map(|ext| ext == "svg").unwrap_or(false) {
                 total += 1;
-                let dst = target_dir.join(src.file_name().unwrap());
-                if fs::copy(&src, &dst).is_err() {
-                    failed.push(src.file_name().unwrap().to_string_lossy().to_string());
+                if let Some(file_name) = src.file_name() {
+                    let dst = target_dir.join(file_name);
+                    if fs::copy(&src, &dst).is_err() {
+                        failed.push(file_name.to_string_lossy().to_string());
+                    }
+                } else {
+                    // Skip files without valid filenames
+                    failed.push(format!("Invalid filename: {}", src.display()));
                 }
             }
         }


### PR DESCRIPTION
Fixes GitHub Actions release workflow conditions and Scoop auto-push operations, and replaces unsafe `unwrap()` calls in `download_all_icons` to improve reliability and prevent panics.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad0dda52-cb5c-4a64-a7af-c3e7d2c8f5df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad0dda52-cb5c-4a64-a7af-c3e7d2c8f5df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

