### PR TITLE
fix: correct else syntax in badge workflow

### DIFF
--- a/.github/workflows/patch-badges.yml
+++ b/.github/workflows/patch-badges.yml
@@ -46,7 +46,7 @@ jobs:
 
           if git diff --quiet -- "$FILE"; then
             echo "No badge changes detected."
-          else:
+          else
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add "$FILE"


### PR DESCRIPTION
## Summary
- fix syntax in patch-badges workflow by removing stray colon after else

## Testing
- `pre-commit run --files .github/workflows/patch-badges.yml` *(fails: command not found)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0ae1de4c48328b43021e92e69700c