### PR TITLE
fix(ci): use secrets context for optional release pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           ls -l outpkg/homebrew outpkg/scoop || true
 
       - name: Auto-push Homebrew formula (optional)
-        if: secrets.GH_PAT != '' && secrets.HOMEBREW_TAP_REPO != ''
+        if: ${{ secrets.GH_PAT != '' && secrets.HOMEBREW_TAP_REPO != '' }}
         shell: bash
         run: |
           set -e
@@ -202,7 +202,7 @@ jobs:
           git push
 
       - name: Auto-push Scoop manifest (optional)
-        if: secrets.GH_PAT != '' && secrets.SCOOP_BUCKET_REPO != ''
+        if: ${{ secrets.GH_PAT != '' && secrets.SCOOP_BUCKET_REPO != '' }}
         shell: bash
         run: |
           set -e


### PR DESCRIPTION
## Summary
- fix release workflow secret checks for tap and bucket pushes

## Testing
- `cargo test`
- `pre-commit run --files .github/workflows/release.yml` *(fails: command not found; attempted to install but network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b8b9835483288fffd09911849dc9