### PR TITLE
Add get_icon_content method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,17 @@ impl LucideClient {
         Ok(serde_json::to_string_pretty(&self.search_icons(query)?)?)
     }
 
+    /// Get the SVG contents for a given icon name without the `.svg` extension.
+    pub fn get_icon_content(&self, name: &str) -> Result<String, Box<dyn Error>> {
+        let mut path = self.svg_dir.clone();
+        if name.ends_with(".svg") {
+            path.push(name);
+        } else {
+            path.push(format!("{name}.svg"));
+        }
+        Ok(fs::read_to_string(path)?)
+    }
+
     /// Copy all SVG files into target dir. Returns (total_found, failed_names)
     pub fn download_all_icons<P: AsRef<Path>>(
         &self,

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,0 +1,16 @@
+use lucide_svg_rs::{LucideClient, ICONS_DIR};
+
+#[test]
+fn test_get_icon_content_returns_svg() {
+    let client = LucideClient::new(ICONS_DIR).unwrap();
+    let svg = client.get_icon_content("activity").unwrap();
+    assert!(svg.contains("<svg"));
+    assert!(svg.contains("</svg>"));
+}
+
+#[test]
+fn test_get_icon_content_missing_icon_errors() {
+    let client = LucideClient::new(ICONS_DIR).unwrap();
+    let result = client.get_icon_content("does-not-exist");
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- add `get_icon_content` for fetching raw SVG by icon name
- exercise `get_icon_content` through new tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c93a0e1083289107dfd702f1ad32